### PR TITLE
update graphql scheme per the changes to synse server making blink a power state

### DIFF
--- a/synse_graphql/prometheus.py
+++ b/synse_graphql/prometheus.py
@@ -138,7 +138,7 @@ class LedDevice(Device):
 
     _handlers = {
         'color': lambda x: int(x, 16),
-        'state': lambda x: x,
+        'state': lambda x: ['off', 'on', 'blink'].index(x),
     }
 
     def record(self):

--- a/synse_graphql/prometheus.py
+++ b/synse_graphql/prometheus.py
@@ -40,7 +40,6 @@ query = '''{
                   humidity
                 }
                 ... on LedDevice {
-                    blink
                     color
                     state
                 }
@@ -138,9 +137,8 @@ class Device(object):
 class LedDevice(Device):
 
     _handlers = {
-        'blink': lambda x: 0 if x == 'steady' else 1,
         'color': lambda x: int(x, 16),
-        'state': lambda x: 0 if x == 'off' else 1,
+        'state': lambda x: x,
     }
 
     def record(self):

--- a/synse_graphql/schema/device.py
+++ b/synse_graphql/schema/device.py
@@ -177,7 +177,6 @@ class LedDevice(DeviceBase):
     """
 
     _resolve_fields = [
-        'blink',
         'color',
         'state',
     ]
@@ -185,7 +184,6 @@ class LedDevice(DeviceBase):
     class Meta:
         interfaces = (DeviceInterface, )
 
-    blink = graphene.String(required=True)
     color = graphene.String(required=True)
     state = graphene.String(required=True)
 

--- a/tests/integration/test_device.py
+++ b/tests/integration/test_device.py
@@ -64,7 +64,6 @@ class TestDevice(BaseSchemaTest):
 
     def test_led(self):
         keys = [
-            "blink",
             "color",
             "state"
         ]

--- a/tests/queries/test_led_device.graphql
+++ b/tests/queries/test_led_device.graphql
@@ -3,7 +3,6 @@
     boards {
       devices(device_type:"led") {
         ... on LedDevice {
-          blink
           color
           state
         }


### PR DESCRIPTION
This essentially just removes 'blink' as a query param/action. Instead, it is now a valid value for the 'state' query param/action.